### PR TITLE
Commit

### DIFF
--- a/taskharbor/worker_heartbeat_lease_test.go
+++ b/taskharbor/worker_heartbeat_lease_test.go
@@ -19,6 +19,7 @@ type leaseFailDriver struct {
 	extendCalls int
 }
 
+// HELPERS.
 func (d *leaseFailDriver) Enqueue(ctx context.Context, rec driver.JobRecord) error {
 	return d.inner.Enqueue(ctx, rec)
 }


### PR DESCRIPTION
Milestone 4: worker heartbeat + lease-loss cancellation

- Added per-job heartbeat to extend leases while handlers run.
- Heartbeat failure cancels the handler context.
- Added worker heartbeat test and adjusted retry tests to wait until retry is scheduled before advancing fake time.
