### PR TITLE
Completed reserve

### DIFF
--- a/taskharbor/driver/postgres/postgres_reserve_test.go
+++ b/taskharbor/driver/postgres/postgres_reserve_test.go
@@ -1,0 +1,142 @@
+package postgres
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/ARJ2211/taskharbor/taskharbor/driver"
+	"github.com/ARJ2211/taskharbor/taskharbor/internal/envutil"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestReserve_NoJobs(t *testing.T) {
+	_ = envutil.LoadRepoDotenv(".")
+	dsn := os.Getenv("TASKHARBOR_TEST_DSN")
+	if dsn == "" {
+		t.Skip("TASKHARBOR_TEST_DSN not set")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	defer pool.Close()
+
+	if err := ApplyMigrations(ctx, pool); err != nil {
+		t.Fatalf("ApplyMigrations: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `TRUNCATE th_jobs`); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+
+	d, err := NewWithPool(pool)
+	if err != nil {
+		t.Fatalf("NewWithPool: %v", err)
+	}
+
+	_, _, ok, err := d.Reserve(ctx, "default", time.Now().UTC(), 5*time.Second)
+	if err != nil {
+		t.Fatalf("Reserve err: %v", err)
+	}
+	if ok {
+		t.Fatalf("expected ok=false")
+	}
+}
+
+func TestReserve_NoDoubleReserve_AndReclaim(t *testing.T) {
+	_ = envutil.LoadRepoDotenv(".")
+	dsn := os.Getenv("TASKHARBOR_TEST_DSN")
+	if dsn == "" {
+		t.Skip("TASKHARBOR_TEST_DSN not set")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	defer pool.Close()
+
+	if err := ApplyMigrations(ctx, pool); err != nil {
+		t.Fatalf("ApplyMigrations: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `TRUNCATE th_jobs`); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+
+	d, err := NewWithPool(pool)
+	if err != nil {
+		t.Fatalf("NewWithPool: %v", err)
+	}
+
+	now1 := time.Now().UTC()
+
+	// Due scheduled job (run_at in the past) so first reserve returns a non-zero RunAt.
+	rec := driver.JobRecord{
+		ID:          "job_sched_1",
+		Type:        "t",
+		Queue:       "default",
+		Payload:     []byte(`{}`),
+		RunAt:       now1.Add(-1 * time.Minute),
+		Timeout:     1 * time.Second,
+		CreatedAt:   now1,
+		Attempts:    0,
+		MaxAttempts: 3,
+	}
+
+	if err := d.Enqueue(ctx, rec); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+
+	r1, l1, ok, err := d.Reserve(ctx, "default", now1, 1*time.Second)
+	if err != nil {
+		t.Fatalf("Reserve#1: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected ok=true")
+	}
+	if r1.ID != rec.ID {
+		t.Fatalf("expected %s got %s", rec.ID, r1.ID)
+	}
+	if r1.RunAt.IsZero() {
+		t.Fatalf("expected first reserve to keep original run_at (scheduled due)")
+	}
+
+	// second reserve while lease valid should return ok=false
+	_, _, ok2, err := d.Reserve(ctx, "default", now1, 1*time.Second)
+	if err != nil {
+		t.Fatalf("Reserve#2: %v", err)
+	}
+	if ok2 {
+		t.Fatalf("expected ok=false while lease is valid")
+	}
+
+	// reclaim after lease expiry (advance 'now' manually)
+	now2 := now1.Add(2 * time.Second)
+	r2, l2, ok3, err := d.Reserve(ctx, "default", now2, 1*time.Second)
+	if err != nil {
+		t.Fatalf("Reserve#3 (reclaim): %v", err)
+	}
+	if !ok3 {
+		t.Fatalf("expected ok=true after expiry")
+	}
+	if r2.ID != rec.ID {
+		t.Fatalf("expected reclaimed job id %s got %s", rec.ID, r2.ID)
+	}
+	if !r2.RunAt.IsZero() {
+		t.Fatalf("expected reclaim to clear run_at to zero (NULL in DB), got %v", r2.RunAt)
+	}
+	if l1.Token == l2.Token {
+		t.Fatalf("expected new lease token after reclaim")
+	}
+	if !l2.ExpiresAt.After(now2) {
+		t.Fatalf("expected lease expiry after now2")
+	}
+}

--- a/taskharbor/driver/postgres/queries.go
+++ b/taskharbor/driver/postgres/queries.go
@@ -1,5 +1,29 @@
 package postgres
 
+/*
+QEnqueue inserts a new job row into th_jobs.
+
+What it does
+- Writes the stable JobRecord fields into Postgres so the worker can later Reserve/lease it.
+- Uses NULL for run_at when the job should be runnable immediately (Go time.Time{}).
+
+Columns written
+- id, type, queue, payload: identity + routing + bytes payload.
+- run_at:
+  - NULL means runnable now
+  - non-NULL means scheduled (Reserve must wait until run_at <= now)
+
+- timeout_nanos: stored as int64 nanoseconds (time.Duration).
+- created_at: stable insertion time (used for FIFO ordering).
+- attempts, max_attempts: retry bookkeeping.
+- last_error, failed_at: failure bookkeeping (failed_at is NULL when zero time in Go).
+- status: set to "ready" at insert.
+- idempotency_key: stored (uniqueness enforced in milestone 6).
+
+Important invariants
+- Enqueue never sets leases or DLQ fields.
+- Scheduling is represented only by run_at being NULL vs non-NULL.
+*/
 const QEnqueue = `
 INSERT INTO th_jobs (
 	id,
@@ -18,4 +42,96 @@ INSERT INTO th_jobs (
 ) VALUES (
 	$1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13
 )
+`
+
+/*
+QReserve atomically selects the next runnable job and leases it.
+
+High-level behavior
+- Finds one candidate row for the queue that is runnable at the provided 'now' time.
+- Locks that row with FOR UPDATE SKIP LOCKED so concurrent workers never lease the same job.
+- Updates the row to inflight and sets a fresh lease token + lease expiry.
+- Reclaims expired inflight jobs and makes them run immediately (run_at becomes NULL), matching memory semantics.
+
+Candidate selection (cte)
+- Filters by queue.
+- Ignores terminal states: status NOT IN ('done','dlq').
+- Eligible rows are either:
+ 1. Ready and due:
+    - status = 'ready'
+    - run_at IS NULL (immediate) OR run_at <= now (scheduled but due)
+ 2. Inflight but lease has expired (reclaim):
+    - status = 'inflight'
+    - lease_expires_at <= now
+
+Ordering (priority)
+- Priority 0: ready + run_at IS NULL (immediate FIFO)
+- Priority 1: inflight + expired lease (reclaim)
+- Priority 2: ready + run_at <= now (scheduled due)
+Then tie-breakers:
+- created_at ASC (FIFO)
+- run_at ASC NULLS LAST (scheduled due earlier first)
+- id ASC (stable ordering)
+
+Atomic lease update (UPDATE ... FROM cte)
+- Sets:
+  - status = 'inflight'
+  - lease_token = $3
+  - lease_expires_at = $4
+
+- Reclaim rule:
+  - run_at = NULL only when the row was previously inflight
+  - this makes reclaimed jobs runnable immediately after reclaim (parity with memory reclaim behavior)
+
+Return values
+- Returns the full row fields needed to build:
+  - driver.JobRecord (id/type/queue/payload/run_at/timeout/created_at/attempts/max_attempts/last_error/failed_at/idempotency_key)
+  - driver.Lease (lease_token, lease_expires_at)
+*/
+const QReserve = `
+WITH cte AS (
+  SELECT id
+  FROM th_jobs
+  WHERE queue = $1
+    AND status NOT IN ('done', 'dlq')
+    AND (
+      (status = 'ready' AND (run_at IS NULL OR run_at <= $2))
+      OR
+      (status = 'inflight' AND lease_expires_at <= $2)
+    )
+  ORDER BY
+    CASE
+      WHEN status = 'ready' AND run_at IS NULL THEN 0
+      WHEN status = 'inflight' AND lease_expires_at <= $2 THEN 1
+      ELSE 2
+    END,
+    created_at ASC,
+    run_at ASC NULLS LAST,
+    id ASC
+  FOR UPDATE SKIP LOCKED
+  LIMIT 1
+)
+UPDATE th_jobs j
+SET
+  status = 'inflight',
+  lease_token = $3,
+  lease_expires_at = $4,
+  run_at = CASE WHEN j.status = 'inflight' THEN NULL ELSE j.run_at END
+FROM cte
+WHERE j.id = cte.id
+RETURNING
+  j.id,
+  j.type,
+  j.queue,
+  j.payload,
+  j.run_at,
+  j.timeout_nanos,
+  j.idempotency_key,
+  j.created_at,
+  j.attempts,
+  j.max_attempts,
+  j.last_error,
+  j.failed_at,
+  j.lease_token,
+  j.lease_expires_at
 `


### PR DESCRIPTION
Summary
- Implemented Driver.Reserve for Postgres using SELECT ... FOR UPDATE SKIP LOCKED in a transaction.
- Atomically leases jobs (status=inflight, lease_token, lease_expires_at).
- Supports reclaiming expired leases and clears run_at on reclaim to match memory semantics.
- Added integration tests covering no-double-reserve and reclaim behavior (runs when TASKHARBOR_TEST_DSN is set).

Closes #60 