### PR TITLE
Memory stress test

### DIFF
--- a/stress/backend-factory.go
+++ b/stress/backend-factory.go
@@ -29,9 +29,14 @@ func newBackend(ctx context.Context, cfg Config) (backend, error) {
 		return newPostgresBackend(ctx, cfg)
 	case "redis":
 		return newRedisBackend(ctx, cfg)
+	case "memory":
+		return newMemoryBackend(ctx, cfg)
 	default:
 		return backend{}, ErrInvalidDriver
 	}
 }
 
-var ErrInvalidDriver = errors.New("invalid driver")
+var (
+	ErrNotImplemented = errors.New("driver not implemented")
+	ErrInvalidDriver  = errors.New("invalid driver")
+)

--- a/stress/backend-memory.go
+++ b/stress/backend-memory.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	"github.com/ARJ2211/taskharbor/taskharbor/driver/memory"
+)
+
+func newMemoryBackend(ctx context.Context, cfg Config) (backend, error) {
+	_ = cfg
+	_ = ctx
+
+	d := memory.New()
+
+	return backend{
+		Driver:   d,
+		DriverID: "memory",
+
+		CloseFn: func() error {
+			return d.Close()
+		},
+
+		ResetFn: func(ctx context.Context) error {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			return d.Reset()
+		},
+
+		ProgFn: func(ctx context.Context, qs []string, now time.Time) (Progress, error) {
+			if err := ctx.Err(); err != nil {
+				return Progress{}, err
+			}
+
+			var ready, scheduled, inflight, dlq int64
+			for _, q := range qs {
+				ready += int64(d.RunnableSize(q))
+				scheduled += int64(d.ScheduledSize(q))
+				inflight += int64(d.InflightSize(q))
+				dlq += int64(d.DLQSize(q))
+			}
+
+			doneApprox := atomic.LoadInt64(&okCount)
+
+			return Progress{
+				Now:        now,
+				Done:       doneApprox,
+				DoneApprox: true,
+				DLQ:        dlq,
+				Ready:      ready,
+				Scheduled:  scheduled,
+				Inflight:   inflight,
+			}, nil
+		},
+	}, nil
+}

--- a/stress/config.go
+++ b/stress/config.go
@@ -54,7 +54,7 @@ func parseConfigOrExit() Config {
 
 	var cfg Config
 
-	flag.StringVar(&cfg.DriverType, "driver", "", "required: postgres | redis")
+	flag.StringVar(&cfg.DriverType, "driver", "", "required: postgres | redis | memory")
 
 	flag.IntVar(&cfg.TotalJobs, "jobs", 120000, "total jobs to enqueue")
 	flag.IntVar(&cfg.NumQueues, "queues", 16, "number of queues (q0..qN)")
@@ -121,8 +121,10 @@ func parseConfigOrExit() Config {
 		if strings.TrimSpace(cfg.RedisPrefix) == "" {
 			log.Fatal("invalid -prefix (empty)")
 		}
+	case "memory":
+		break
 	default:
-		log.Fatalf("invalid -driver=%s (must be postgres|redis)", cfg.DriverType)
+		log.Fatalf("invalid -driver=%s (must be postgres|redis|memory)", cfg.DriverType)
 	}
 
 	return cfg

--- a/taskharbor/driver/memory/memory.go
+++ b/taskharbor/driver/memory/memory.go
@@ -62,6 +62,23 @@ type inflightItem struct {
 }
 
 /*
+Reset clears all in-memory state so the driver
+behaves like a fresh instance.
+This is mainly useful for stress tests and debugging.
+*/
+func (d *Driver) Reset() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	// wipe everything
+	d.queues = make(map[string]*queueState)
+	d.inflightIndex = make(map[string]string)
+	d.idemIndex = make(map[string]string)
+	d.closed = false
+	return nil
+}
+
+/*
 ScheduledSize returns number of scheduled jobs for a queue.
 This is mainly useful for stress tests and debugging.
 */


### PR DESCRIPTION
What changed
- Implemented newMemoryBackend so examples/stress can run with -driver=memory.
- Added in-place Reset() to the memory driver so the stress runner can clear state without recreating the backend.
- Added lightweight queue metrics for memory: ScheduledSize() and DLQSize(), so Progress() can report ready/scheduled/inflight/dlq consistently across drivers.
- Memory “Done” is reported as an approximation (same as Redis) using the handler success counter, since the memory driver intentionally does not persist a terminal “done” store (Ack removes inflight state).